### PR TITLE
Feature/ Use ES6 module syntax to import image

### DIFF
--- a/practice/src/js/constants/image.js
+++ b/practice/src/js/constants/image.js
@@ -1,3 +1,0 @@
-const defaultImage = require('../../assets/images/default.png');
-
-export default defaultImage;

--- a/practice/src/js/templates/productTemplate.js
+++ b/practice/src/js/templates/productTemplate.js
@@ -2,7 +2,7 @@ import iconAction from '../../assets/images/icons/icons.svg';
 import renderFormInputTemplate from '../templates/formInputTemplate';
 import debounce from '../helpers/debounce';
 import { MESSAGES } from '../constants/message';
-import defaultImage from '../constants/image';
+import defaultImage from '../../assets/images/default.png';
 
 export default class ProductTemplate {
   /**


### PR DESCRIPTION
Description: This PR is used to switch from using `require` to ES6 `import` for importing the default image asset.

Ticket: [Fix public presentation feedback](https://trello.com/c/W8nSUadg/54-fix-public-presentation-feedback)